### PR TITLE
add plumbing for group-by-table #10

### DIFF
--- a/odp/core/types.py
+++ b/odp/core/types.py
@@ -1,3 +1,6 @@
+from enum import Enum
+
+import click
 from pydantic import BaseModel
 
 
@@ -12,3 +15,29 @@ class SchemaRow(BaseModel):
     TABLE_SCHEMA: str
     TABLE_NAME: str
     COLUMN_NAME: str
+
+
+class Dialect(Enum):
+    snowflake = "snowflake"
+    bigquery = "bigquery"
+    redshift = "redshift"
+
+def validate_dialect(ctx, param, value):
+    try:
+        return Dialect(value)
+    except ValueError:
+        raise click.BadParameter(
+            f'Invalid dialect value: {value}. Valid values are: {", ".join(d.value for d in Dialect)}')
+
+
+class Grain(Enum):
+    schema = "schema"
+    table = "table"
+    column = "column"
+
+def validate_grain(ctx, param, value):
+    try:
+        return Grain(value)
+    except ValueError:
+        raise click.BadParameter(
+            f'Invalid grain value: {value}. Valid values are: {", ".join(g.value for g in Grain)}')


### PR DESCRIPTION
related to #10 - not a full impl



```
poetry run python -m odp detect-unused --help
Usage: python -m odp detect-unused [OPTIONS]

  Detect unused columns in SQL queries.  Requires two files: a query file and
  an information schema file.  Run `show-queries` to see the SQL queries to
  run against your  Snowflake instance to generate the two files.

Options:
  --queries_file TEXT             The SQL query file to analyze.
  --info_schema_file TEXT         The file containing the information schema
                                  for the database.
  --dialect [snowflake|bigquery|redshift]
                                  The type of warehouse to connect to.
                                  Currently only snowflake is supported.
  --grain [table|column]          the grain to search for, e.g. use
                                  --grain=table to search for unused tables.
                                  Default is column.
  --help                          Show this message and exit.
```