### PR TITLE
scope by time, update files params

### DIFF
--- a/odp/cli/main.py
+++ b/odp/cli/main.py
@@ -27,8 +27,8 @@ Requires two files: a query file and an information schema file.
 Run `show-queries` to see the SQL queries to run against your
 Snowflake instance to generate the two files.""",
 )
-@click.option("--queries_file", help="The SQL query file to analyze.")
-@click.option("--info_schema_file", help="The file containing the information schema for the database.")
+@click.option("--queries-file", help="The SQL query file to analyze.")
+@click.option("--info-schema-file", help="The file containing the information schema for the database.")
 @click.option(
     "--dialect",
     type=click.Choice([d.value for d in Dialect]),
@@ -43,14 +43,21 @@ Snowflake instance to generate the two files.""",
     default="table",
     help="the grain to search for, e.g. use --grain=column to search for unused tables. Default is table.",
 )
+@click.option(
+    "--since-days",
+    type=click.INT,
+    default=60,
+    help="Count as 'unused' any asset that has not been queried in the last N days. Defaults to 60 days",
+)
 def cli_detect_unused_columns(
     queries_file: str | None,
     info_schema_file: str | None,
     dialect: Dialect,
     grain: Grain,
+    since_days: int,
 ):
     if queries_file and info_schema_file:
-        queries = read_queries(queries_file)
+        queries = read_queries(queries_file, since_days)
         print(f"Read {len(queries)} queries from {queries_file}")
 
         info_schema, info_schema_flat = read_info_schema_from_file(info_schema_file)
@@ -72,13 +79,13 @@ def cli_detect_unused_columns(
                 f"""
 Missing or invalid parameters: {e}. Please provide either
 
-   1. both of --info_schema_file and --queries_file (use "odp show-queries" to generate these
+   1. both of --info_schema-file and --queries-file (use "odp show-queries" to learn how to generate these)
    2. valid crendentials via env, e.g. ODP_SNOWFLAKE_ACCOUNT, ODP_SNOWFLAKE_USER, etc
             """
             )
 
         schema = get_snowflake_schema(credentials)
-        queries = get_snowflake_queries(credentials)
+        queries = get_snowflake_queries(credentials, since_days)
 
         info_schema, info_schema_flat = build_info_schema(schema)
         if grain == Grain.column:
@@ -95,7 +102,8 @@ Missing or invalid parameters: {e}. Please provide either
 
 @cli.command("show-queries")
 def show_snowflake_queries():
-    print("Run the below against your snowflake instance to generate a dataset you can" "export to CSV for analysis")
+    print(
+        "Run the below against your snowflake instance to generate a dataset you can" "export to CSV for analysis")
     print(
         """
 -- query_file

--- a/odp/core/types.py
+++ b/odp/core/types.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 
 import click
@@ -6,6 +7,7 @@ from pydantic import BaseModel
 
 class QueryRow(BaseModel):
     QUERY_TEXT: str
+    START_TIME: datetime
     DATABASE_NAME: str | None
     SCHEMA_NAME: str | None
 


### PR DESCRIPTION
implement the `--since-days` flag, fixes #5

also change - to _ in cli params, fixes #15

Example
---------

	$ python odp/cli/main.py detect-unused --grain=table --since-days=3
	Most common tables (20):
	DEX_DEV.INFORMATION_SCHEMA.COLUMNS: 35
	SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY: 28
	.INFORMATION_SCHEMA.COLUMNS: 3
	PUBLIC.INFORMATION_SCHEMA.COLUMNS: 1
	Unused tables (13):
	(DEX_DEV, DEX_DEV, ACCOUNT)
	(DEX_DEV, DEX_DEV, COMMENTS)
	(DEX_DEV, DEX_DEV, CYCLES)
	(DEX_DEV, DEX_DEV, FAKE)
	(DEX_DEV, DEX_DEV, ISSUES)
	(DEX_DEV, DEX_DEV, OPPORTUNITY)
	(DEX_DEV, DEX_DEV, USERS)
	(DEX_DEV, DEX_DEV, WORKFLOWSTATES)
	(DEX_DEV, LINEAR, COMMENTS)
	(DEX_DEV, LINEAR, CYCLES)
	(DEX_DEV, LINEAR, ISSUES)
	(DEX_DEV, LINEAR, USERS)
	(DEX_DEV, LINEAR, WORKFLOWSTATES)

with queries-file and schema-file (compare `since-days=10` vs. `since-days=120`)

	$ python odp/cli/main.py detect-unused --grain=table --since-days=10 --info-schema-file ~/Downloads/columns_small.csv --queries-file ~/Downloads/Audit\ Logs\ \(2\).csv
	Read 0 queries from /Users/dex/Downloads/Audit Logs (2).csv
	Read 171 information schema rows from /Users/dex/Downloads/columns_small.csv
	Most common tables (20):
	Unused tables (13):
	('DEX_DEV', 'DEX_DEV', 'ACCOUNT')
	('DEX_DEV', 'DEX_DEV', 'COMMENTS')
	('DEX_DEV', 'DEX_DEV', 'CYCLES')
	('DEX_DEV', 'DEX_DEV', 'FAKE')
	('DEX_DEV', 'DEX_DEV', 'ISSUES')
	('DEX_DEV', 'DEX_DEV', 'OPPORTUNITY')
	('DEX_DEV', 'DEX_DEV', 'USERS')
	('DEX_DEV', 'DEX_DEV', 'WORKFLOWSTATES')
	('DEX_DEV', 'LINEAR', 'COMMENTS')
	('DEX_DEV', 'LINEAR', 'CYCLES')
	('DEX_DEV', 'LINEAR', 'ISSUES')
	('DEX_DEV', 'LINEAR', 'USERS')
	('DEX_DEV', 'LINEAR', 'WORKFLOWSTATES')

with `since-days=120`

	$ python odp/cli/main.py detect-unused --grain=table --since-days=120 --info-schema-file ~/Downloads/columns_small.csv --queries-file ~/Downloads/Audit\ Logs\ \(2\).csv
	Read 1000 queries from /Users/dex/Downloads/Audit Logs (2).csv
	Read 171 information schema rows from /Users/dex/Downloads/columns_small.csv
	Most common tables (20):
	.INFORMATION_SCHEMA.COLUMNS: 229
	DEX_DEV.LINEAR.ISSUES: 115
	SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY: 52
	.DEX_DEV.ISSUES: 17
	DEX_DEV.LINEAR.CYCLES: 14
	DEX_DEV.DEX_DEV.ISSUES: 13
	.LINEAR.ISSUES: 11
	.DEX_DEV.CYCLES: 10
	DEX_DEV.DEX_DEV.WORKFLOWSTATES: 9
	.DEX_DEV.WORKFLOWSTATES: 9
	PUBLIC.INFORMATION_SCHEMA.COLUMNS: 7
	DEX_DEV.LINEAR.WORKFLOWSTATES: 6
	.DEX_DEV.USERS: 6
	DEX_DEV.DEX_DEV.CYCLES: 6
	SNOWFLAKE.ACCOUNT_USAGE.METERING_HISTORY: 4
	DEX_DEV.LINEAR.USERS: 3
	..IDENTIFIER: 3
	ACCOUNT_USAGE.INFORMATION_SCHEMA.COLUMNS: 2
	DEX_DEV.LINEAR.COMMENTS: 2
	DEX_DEV.DEX_DEV.USERS: 2
	Unused tables (4):
	('DEX_DEV', 'DEX_DEV', 'ACCOUNT')
	('DEX_DEV', 'DEX_DEV', 'COMMENTS')
	('DEX_DEV', 'DEX_DEV', 'FAKE')
	('DEX_DEV', 'DEX_DEV', 'OPPORTUNITY')